### PR TITLE
Add phoromatic user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,19 @@ RUN apt-get update -y \
     && apt-get autoremove -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
+# Create phoromatic user and group
+RUN groupadd -r phoromatic && useradd -r -g phoromatic phoromatic \
+    && mkdir -p /phoronix-test-suite \
+    && chown -R phoromatic:phoromatic /phoronix-test-suite
+
 # Set environment variable for Phoromatic server port
 ENV PHOROMATIC_HTTP_PORT=8287
 
 # Expose Phoromatic server port
 EXPOSE 8287/tcp
+
+# Use phoromatic user to run the server
+USER phoromatic
 
 # Start Phoromatic server when container starts
 CMD ["/phoronix-test-suite/phoronix-test-suite", "start-phoromatic-server"]


### PR DESCRIPTION
## Summary
- add group/user creation commands in the Dockerfile
- adjust permissions and use phoromatic user to run the server

## Testing
- `docker build` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c33c4a7948331ac3f342e5321b368