### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @org/maintainers


### PR DESCRIPTION
## Summary
- define default code owners in `.github/CODEOWNERS`

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c34034fb88331a26ab8e0a599c965