### PR TITLE
Fix Dockerfile cleanup comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@ RUN apt-get update -y \
        unzip \
        php-zip \
        build-essential \
-       autoconf \
-    # Clean up to reduce image size
-    && apt-get clean autoclean \
+       autoconf
+
+# Clean up to reduce image size
+RUN apt-get clean autoclean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 


### PR DESCRIPTION
## Summary
- prevent comment from continuing autoconf line in Dockerfile by ending the install command
- start cleanup steps in a separate `RUN` layer

## Testing
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c3406e0bc83319c1dee6822c796eb