### PR TITLE
Use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,45 @@
-# Use phoronix/pts as the base image
-FROM phoronix/pts:latest
+# -------- Builder Stage ----------------------------------------------------
+FROM ubuntu:20.04 AS builder
 
 # Avoid prompts from apt
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update and install necessary packages
+# Install tools required for building the Phoronix Test Suite
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends --no-install-suggests \
+       git \
+       build-essential \
+       autoconf \
+       php-cli \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+WORKDIR /tmp
+
+# Fetch and install the Phoronix Test Suite
+RUN git clone https://github.com/phoronix-test-suite/phoronix-test-suite.git \
+    && cd phoronix-test-suite \
+    && ./install-sh /usr
+
+# -------- Runtime Stage ----------------------------------------------------
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install only the packages required at runtime
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+       php-cli \
        php-sqlite3 \
        zip \
        unzip \
        php-zip \
-       build-essential \
-       autoconf \
-    # Clean up to reduce image size
     && apt-get clean autoclean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+# Copy the built Phoronix Test Suite from the builder image
+COPY --from=builder /usr/bin/phoronix-test-suite /usr/bin/phoronix-test-suite
+COPY --from=builder /usr/share/phoronix-test-suite /usr/share/phoronix-test-suite
 
 # Set environment variable for Phoromatic server port
 ENV PHOROMATIC_HTTP_PORT=8287
@@ -25,4 +48,4 @@ ENV PHOROMATIC_HTTP_PORT=8287
 EXPOSE 8287/tcp
 
 # Start Phoromatic server when container starts
-CMD ["/phoronix-test-suite/phoronix-test-suite", "start-phoromatic-server"]
+CMD ["phoronix-test-suite", "start-phoromatic-server"]


### PR DESCRIPTION
## Summary
- build Phoronix Test Suite in a builder stage
- copy built files into a runtime image with only php packages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686c33fd97488331907219215c95f92a