### PR TITLE
Add Docker build CI workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,21 @@
+---
+# yamllint disable rule:truthy
+name: Docker Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: docker build -t phoromatic .
+      - name: Run container test
+        run: |
+          timeout 30s docker run --rm phoromatic \
+            /phoronix-test-suite start-phoromatic-server


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the Dockerfile and run the Phoromatic server in CI
- fix YAML style and disable yamllint truthy rule

## Testing
- `yamllint .github/workflows/docker-build.yml`

------
https://chatgpt.com/codex/tasks/task_e_686c340f86cc8331bf04260f05fbb59a